### PR TITLE
fix: keep `twoslash` graph out of `Code.astro` chunk

### DIFF
--- a/.changeset/fix-twoslash-chunk.md
+++ b/.changeset/fix-twoslash-chunk.md
@@ -1,0 +1,5 @@
+---
+'starlight-theme-nova': patch
+---
+
+Fix a `__filename is not defined in ES module scope` build error when the theme is installed with pnpm.

--- a/packages/starlight-theme-nova/src/components/Code.astro
+++ b/packages/starlight-theme-nova/src/components/Code.astro
@@ -1,12 +1,14 @@
 ---
 import type { ComponentProps } from 'astro/types'
 import { Code as CodeComponent } from 'astro:components'
-import { createShikiConfig } from '../shiki-config'
+import { createBaseShikiConfig } from '../shiki-config-base'
 
 type Props = ComponentProps<typeof CodeComponent>
 
-// For unknown reasons, enabling twoslash breaks the build, thus twoslash is disabled here.
-const shikiConfig = createShikiConfig({ twoslash: false })
+// Twoslash must stay out of this component's import graph: component chunks
+// are bundled into ESM prerender chunks, and the CommonJS `typescript` package
+// pulled in by twoslash crashes there (`__filename` is not defined in ESM).
+const shikiConfig = createBaseShikiConfig()
 ---
 
 <CodeComponent {...shikiConfig} {...Astro.props} />

--- a/packages/starlight-theme-nova/src/shiki-config-base.ts
+++ b/packages/starlight-theme-nova/src/shiki-config-base.ts
@@ -1,0 +1,40 @@
+import {
+  transformerMetaHighlight,
+  transformerMetaWordHighlight,
+  transformerNotationDiff,
+  transformerRemoveNotationEscape,
+  transformerNotationHighlight,
+  transformerNotationWordHighlight,
+} from '@shikijs/transformers'
+import type { ShikiTransformer } from '@shikijs/types'
+import type { ShikiConfig } from 'astro'
+
+import { transformerContainer } from './shiki-transformer-container'
+
+/**
+ * The Shiki config without twoslash. Safe to import from `.astro` components:
+ * this module must never import twoslash, which pulls in the CommonJS
+ * `typescript` package that cannot be bundled into ESM prerender chunks.
+ */
+export function createBaseShikiConfig(
+  extraTransformers: ShikiTransformer[] = [],
+): ShikiConfig {
+  return {
+    themes: {
+      light: 'one-light',
+      dark: 'github-dark-dimmed',
+    },
+    defaultColor: false,
+    transformers: [
+      transformerMetaHighlight(),
+      transformerMetaWordHighlight(),
+      transformerNotationDiff(),
+      transformerNotationHighlight(),
+      transformerNotationWordHighlight(),
+      transformerRemoveNotationEscape(),
+
+      transformerContainer(),
+      ...extraTransformers,
+    ],
+  }
+}

--- a/packages/starlight-theme-nova/src/shiki-config.ts
+++ b/packages/starlight-theme-nova/src/shiki-config.ts
@@ -1,29 +1,12 @@
-import {
-  transformerMetaHighlight,
-  transformerMetaWordHighlight,
-  transformerNotationDiff,
-  transformerRemoveNotationEscape,
-  transformerNotationHighlight,
-  transformerNotationWordHighlight,
-} from '@shikijs/transformers'
 import { transformerTwoslash } from '@shikijs/twoslash'
-import type { ShikiTransformer } from '@shikijs/types'
 import type { ShikiConfig } from 'astro'
 import { createRenderer } from 'shiki-twoslash-renderer'
 
-import { transformerContainer } from './shiki-transformer-container'
+import { createBaseShikiConfig } from './shiki-config-base'
 
 export function createShikiConfig(options: { twoslash: boolean }): ShikiConfig {
-  const transformers: ShikiTransformer[] = [
-    transformerMetaHighlight(),
-    transformerMetaWordHighlight(),
-    transformerNotationDiff(),
-    transformerNotationHighlight(),
-    transformerNotationWordHighlight(),
-    transformerRemoveNotationEscape(),
-
-    transformerContainer(),
-    ...(options.twoslash
+  return createBaseShikiConfig(
+    options.twoslash
       ? [
           transformerTwoslash({
             renderer: createRenderer(),
@@ -35,15 +18,6 @@ export function createShikiConfig(options: { twoslash: boolean }): ShikiConfig {
             },
           }),
         ]
-      : []),
-  ]
-
-  return {
-    themes: {
-      light: 'one-light',
-      dark: 'github-dark-dimmed',
-    },
-    defaultColor: false,
-    transformers: transformers,
-  }
+      : [],
+  )
 }


### PR DESCRIPTION
Splits the Shiki config so `Code.astro` no longer statically imports the twoslash graph, whose CommonJS `typescript` dependency crashes with `__filename is not defined in ES module scope` when bundled into ESM prerender chunks (which happens when the theme is installed standalone with pnpm, since `typescript` is then not resolvable from the project root and cannot be externalized).